### PR TITLE
Replaced Deprecated Library Function

### DIFF
--- a/deploy-fortigate-ncc.py
+++ b/deploy-fortigate-ncc.py
@@ -532,7 +532,7 @@ class GCPStorageClient:
 
         bucket = self.storage_client.bucket(bucket_name)
         blob = bucket.blob(blob_name)
-        json_data = blob.download_as_string().decode('utf-8').replace(' ','').replace('\n', '').replace('\t','')   
+        json_data = blob.download_as_bytes().replace(b' ', b'').replace(b'\n', b'').replace(b'\t', b'').replace(b'\r', b'')   
         return json.loads(json_data)
 
 


### PR DESCRIPTION
- Deprecated blob.download_as_string replaced by blob.download_as_bytes
- Tweaked input regex to work with new format.

Doc for Deprecated Function can be [found HERE ](https://googleapis.dev/python/storage/latest/blobs.html#google.cloud.storage.blob.Blob.download_as_string)